### PR TITLE
fix issue #19: skip dashboard from navbar for non sign_in users

### DIFF
--- a/app/views/layouts/_navbar.html.slim
+++ b/app/views/layouts/_navbar.html.slim
@@ -5,7 +5,8 @@ nav.navbar.navbar-expand-lg.navbar-dark.bg-dark
     ul.navbar-nav.mr-auto
       li.nav-item
         = link_to t("layouts.navbar.home"), root_path, class: "nav-link"
-      li.nav-item
-        = link_to t("layouts.navbar.dashboard"), dashboard_path, class: "nav-link"
+      - if user_signed_in?
+        li.nav-item
+          = link_to t("layouts.navbar.dashboard"), dashboard_path, class: "nav-link"
 
     = render "layouts/user_link_item"


### PR DESCRIPTION
fix issue #19 : skip dashboard link on navbar. Before user sign_in, user will not see dashboard link on navbar, after user sign_in, user will see dashboard link on navbar.