### PR TITLE
Fix #115 Add api controller status rendering methods

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -4,25 +4,25 @@ module Api
 
     def token_authenticate_user
       if authorization_header.blank?
-        render status: :unauthorized, json: { error: t("api.errors.unauthorized") } and return
+        unauthorized("api.errors.unauthorized") and return
       end
 
       unless authenticate_scheme_bearer?
-        render status: :unauthorized, json: { error: t("api.errors.not_bearer_type") } and return
+        unauthorized("api.errors.not_bearer_type") and return
       end
 
       if token_blank?
-        render status: :unauthorized, json: { error: t("api.errors.blank_token") } and return
+        unauthorized("api.errors.blank_token") and return
       end
 
       begin
         set_user
       rescue ActiveRecord::RecordNotFound
-        render status: :unauthorized, json: { error: t("api.errors.not_found") }
+        unauthorized("api.errors.not_found")
       rescue JWT::ExpiredSignature
-        render status: :unauthorized, json: { error: t("api.errors.expired_token") }
+        unauthorized("api.errors.expired_token")
       rescue JWT::DecodeError
-        render status: :unauthorized, json: { error: t("api.errors.unexpected_error") }
+        unauthorized("api.errors.unexpected_error")
       end
     end
 
@@ -54,6 +54,18 @@ module Api
 
     def set_user
       @current_user = User.find(decoded[:id])
+    end
+
+    def unauthorized(message)
+      render status: :unauthorized, json: { error: t(message) }
+    end
+
+    def bad_request(message)
+      render status: :bad_request, json: { error: t(message) }
+    end
+
+    def ok(obj = {})
+      render status: :ok, json: obj
     end
   end
 end


### PR DESCRIPTION
В методе ok параметр по умолчанию будет пустым хэшем, так как в случае если он будет nil, то может привести  ошибке undefined method for nil:NilClass. И внутри метода после json фигурные скобки не нужны, так как объект в параметре будет хэшем и сам обернется в фигурные скобки, иначе будет всегда выбивать syntax error.
Тесты после добавления методов работают нормально.
Если в дальнейшем будем расширять перечень возвращаемых статусов 4xx, то имеет смысл переписать методы примерно в такой вид:
`
def render_client_error(status, error)
  render status: status, json: { error: t(error) }
end

def render_ok(obj = {})
  render status: ok, json: obj
end  
`