### PR TITLE
Close #129 Api sessions service object

### DIFF
--- a/app/services/users/session_create_user_service.rb
+++ b/app/services/users/session_create_user_service.rb
@@ -1,0 +1,22 @@
+module Users
+  class SessionCreateUserService < Service
+    def call(params = {})
+      if params[:email].nil? || params[:password].nil?
+        return failure(I18n.t("api.v1.sessions.errors.no_email_and_password"))
+      end
+
+      user = User.find_by email: params[:email]
+
+      if user.blank? || !user.enable?
+        return failure(I18n.t("api.v1.sessions.errors.user_not_found_blocked"))
+      end
+
+      if !user.valid_password?(params[:password])
+        return failure(I18n.t("api.v1.sessions.errors.incorrect_email_or_password"))
+      end
+
+      token = JwtService.encode(id: user.id, email: user.email, username: user.username)
+      success(token)
+    end
+  end
+end

--- a/app/services/users/session_create_user_service.rb
+++ b/app/services/users/session_create_user_service.rb
@@ -1,17 +1,17 @@
 module Users
   class SessionCreateUserService < Service
-    def call(params = {})
-      if params[:email].nil? || params[:password].nil?
+    def call(email: nil, password: nil)
+      if email.nil? || password.nil?
         return failure(I18n.t("api.v1.sessions.errors.no_email_and_password"))
       end
 
-      user = User.find_by email: params[:email]
+      user = User.find_by email: email
 
       if user.blank? || !user.enable?
         return failure(I18n.t("api.v1.sessions.errors.user_not_found_blocked"))
       end
 
-      if !user.valid_password?(params[:password])
+      if !user.valid_password?(password)
         return failure(I18n.t("api.v1.sessions.errors.incorrect_email_or_password"))
       end
 

--- a/spec/services/users/session_create_user_service_spec.rb
+++ b/spec/services/users/session_create_user_service_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Users::SessionCreateUserService do
+  let(:service) { described_class.new }
+  let(:user) { create(:user) }
+  let(:token) { JwtService.encode(id: user.id, email: user.email, username: user.username) }
+
+  describe ".call" do
+    it "email and password are valid" do
+      result = service.call(email: user.email, password: "password")
+      expect(result.success?).to be true
+      expect(result.data).to eq token
+    end
+
+    it "email is nil" do
+      result = service.call(password: "password")
+      expect(result.failure?).to be true
+      expect(result.error_messages).to eq I18n.t("api.v1.sessions.errors.no_email_and_password")
+    end
+
+    it "password is nil" do
+      result = service.call(email: user.email)
+      expect(result.failure?).to be true
+      expect(result.error_messages).to eq I18n.t("api.v1.sessions.errors.no_email_and_password")
+    end
+
+    it "user is not found" do
+      result = service.call(email: "wrong@email.com", password: "password")
+      expect(result.failure?).to be true
+      expect(result.error_messages).to eq I18n.t("api.v1.sessions.errors.user_not_found_blocked")
+    end
+
+    it "user is blocked" do
+      # TODO: implements after add delete_at field to users model and enable? method
+    end
+
+    it "password is invalid" do
+      result = service.call(email: user.email, password: "wrong password")
+      expect(result.failure?).to be true
+      expect(result.error_messages).to eq I18n.t("api.v1.sessions.errors.incorrect_email_or_password")
+    end
+  end
+end


### PR DESCRIPTION
Весь функционал метода create из api/v1/sessions_controller перенесен в SessionCreateUserService. Внутри все практически такое же как в sessions_controller, но на всякий случай сделал еще один вариант (не хотел в нем записывать юзера в инстанс переменную до проверки входящих параметров, но иначе будет три запроса в БД вместо одного):
```ruby
  module Users
  class SessionCreateUserService < Service
    attr_reader :email, :password, :user

    def initialize(params = {})
      @email = params[:email]
      @password = params[:password]
      @user = User.find_by(email: email)
    end

    def call
      return failure(I18n.t("api.v1.sessions.errors.no_email_and_password")) if email_password_nil?
      return failure(I18n.t("api.v1.sessions.errors.user_not_found_blocked")) if user_blank_blocked?
      return failure(I18n.t("api.v1.sessions.errors.incorrect_email_or_password")) unless user.valid_password?(password)

      token = JwtService.encode(id: user.id, email: user.email, username: user.username)
      success(token)
    end

    private

    def email_password_nil?
      email.nil? || password.nil?
    end

    def user_blank_blocked?
      user.blank? || !user.enable?
    end
  end
end
```

Сам sessions_controller пока не трогал пока не одобрен SessionCreateUserService.