### PR TITLE
Fix #142 Add new session feature

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -17,5 +17,5 @@ hr
       = f.check_box :remember_me, class: "form-check-input"
       = f.label :remember_me
   .actions
-    = f.submit "Log in", class: "btn btn-primary"
+    = f.submit "Log in", class: "btn btn-primary", id: "user_signin_submit"
     = render Button::BaseComponent.new(t("registrations.sign_up"), new_user_registration_path, class: "btn btn-success ml-3")

--- a/features/new_session.feature
+++ b/features/new_session.feature
@@ -1,0 +1,6 @@
+Feature: Session
+  
+    Scenario: I can create new session on site
+      Given I visit on sign in page
+      When I fill email and password and submit form
+      Then I should redirect to projects path and see a new session welcome message

--- a/features/step_definitions/new_session_steps.rb
+++ b/features/step_definitions/new_session_steps.rb
@@ -1,0 +1,14 @@
+Given("I visit on sign in page") do
+  FactoryBot.create(:user, email: "test@test.com", password: "password")
+  visit new_user_session_path
+end
+
+When("I fill email and password and submit form") do
+  fill_in "user_email", with: "test@test.com"
+  fill_in "user_password", with: "password"
+  click_on "user_signin_submit"
+end
+
+Then("I should redirect to projects path and see a new session welcome message") do
+  expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
+end


### PR DESCRIPTION
Вопрос - в feature-registration нужно было добавлять id к каждому элементу text-field во вьюхе. Здесь же пришлось только добавить id к кнопке submit, поля формы email и password не менялись. Получается при наличии полей для email, password и прочих именных параметров cucumber сам заполняет их нужными данными даже без id? И нужно ли тогда для каждого поля формы все равно добавлять id если feature корректно все отрабатывает?