### PR TITLE
Fix #161 Move token_authenticate_user method from api controller to concern

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -3,59 +3,6 @@ module Api
     protect_from_forgery with: :null_session
 
     include ApiResponders
-
-    def token_authenticate_user
-      if authorization_header.blank?
-        unauthorized(t("api.errors.unauthorized")) and return
-      end
-
-      unless authenticate_scheme_bearer?
-        unauthorized(t("api.errors.not_bearer_type")) and return
-      end
-
-      if token_blank?
-        unauthorized(t("api.errors.blank_token")) and return
-      end
-
-      begin
-        set_user
-      rescue ActiveRecord::RecordNotFound
-        unauthorized(t("api.errors.not_found"))
-      rescue JWT::ExpiredSignature
-        unauthorized(t("api.errors.expired_token"))
-      rescue JWT::DecodeError
-        unauthorized(t("api.errors.unexpected_error"))
-      end
-    end
-
-    private
-
-    def authorization_header
-      request.headers["Authorization"]
-    end
-
-    def token
-      authorization_header.split.last
-    end
-
-    def authenticate_scheme_bearer?
-      authenticate_scheme == "Bearer"
-    end
-
-    def authenticate_scheme
-      authorization_header.split.first
-    end
-
-    def decoded
-      JwtService.decode(token)
-    end
-
-    def token_blank?
-      token == authenticate_scheme
-    end
-
-    def set_user
-      @current_user = User.find(decoded[:id])
-    end
+    include ApiAuthenticate
   end
 end

--- a/app/controllers/concerns/api_authenticate.rb
+++ b/app/controllers/concerns/api_authenticate.rb
@@ -1,0 +1,57 @@
+module ApiAuthenticate
+  extend ActiveSupport::Concern
+
+  def token_authenticate_user
+    if authorization_header.blank?
+      unauthorized(t("api.errors.unauthorized")) and return
+    end
+
+    unless authenticate_scheme_bearer?
+      unauthorized(t("api.errors.not_bearer_type")) and return
+    end
+
+    if token_blank?
+      unauthorized(t("api.errors.blank_token")) and return
+    end
+
+    begin
+      set_user
+    rescue ActiveRecord::RecordNotFound
+      unauthorized(t("api.errors.not_found"))
+    rescue JWT::ExpiredSignature
+      unauthorized(t("api.errors.expired_token"))
+    rescue JWT::DecodeError
+      unauthorized(t("api.errors.unexpected_error"))
+    end
+  end
+
+  private
+
+  def authorization_header
+    request.headers["Authorization"]
+  end
+
+  def token
+    authorization_header.split.last
+  end
+
+  def authenticate_scheme_bearer?
+    authenticate_scheme == "Bearer"
+  end
+
+  def authenticate_scheme
+    authorization_header.split.first
+  end
+
+  def decoded
+    JwtService.decode(token)
+  end
+
+  def token_blank?
+    token == authenticate_scheme
+  end
+
+  def set_user
+    @current_user = User.find(decoded[:id])
+  end
+end

--- a/spec/controllers/concerns/api_authenticate_spec.rb
+++ b/spec/controllers/concerns/api_authenticate_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+describe ApiAuthenticate, type: :controller do
+  controller(ApplicationController) do
+    before_action :token_authenticate_user
+
+    include ApiResponders
+    include ApiAuthenticate
+
+    def fake_action
+      head :no_content
+    end
+  end
+
+  let(:user) { create(:user) }
+  let(:token) { JwtService.encode(id: user.id) }
+  let(:expired_token) { JwtService.encode({id: user.id}, DateTime.now) }
+  let(:incorrect_token) { JwtService.encode(id: 'wrong value') }
+
+  before do
+    routes.draw { get "fake_action", to: "anonymous#fake_action" }
+  end
+
+  describe "#token_authenticate_user" do
+    it "bearer token is valid" do
+      request.headers["Authorization"] = "Bearer #{token}"
+      get :fake_action
+      expect(controller.current_user).to eq(user)
+    end
+
+    it "authorization header is nil" do
+      request.headers["Authorization"] = nil
+      get :fake_action
+      expect(response).to have_http_status(:unauthorized)
+      expect(json_response["error"]).to eq I18n.t("api.errors.unauthorized")
+    end
+
+    it "authorization header is blank" do
+      request.headers["Authorization"] = " "
+      get :fake_action
+      expect(response).to have_http_status(:unauthorized)
+      expect(json_response["error"]).to eq I18n.t("api.errors.unauthorized")
+    end
+
+    it "token is not bearer type" do
+      request.headers["Authorization"] = "Basic #{token}"
+      get :fake_action
+      expect(response).to have_http_status(:unauthorized)
+      expect(json_response["error"]).to eq I18n.t("api.errors.not_bearer_type")
+    end
+
+    it "token is blank" do
+      request.headers["Authorization"] = "Bearer "
+      get :fake_action
+      expect(response).to have_http_status(:unauthorized)
+      expect(json_response["error"]).to eq I18n.t("api.errors.blank_token")
+    end
+
+    it "user not found" do
+      request.headers["Authorization"] = "Bearer #{incorrect_token}"
+      get :fake_action
+      expect(response).to have_http_status(:unauthorized)
+      expect(json_response["error"]).to eq I18n.t("api.errors.not_found")
+    end
+
+    it "token is expired" do
+      request.headers["Authorization"] = "Bearer #{expired_token}"
+      get :fake_action
+      expect(response).to have_http_status(:unauthorized)
+      expect(json_response["error"]).to eq I18n.t("api.errors.expired_token")
+    end
+
+    it "bearer token can't be decoded" do
+      request.headers["Authorization"] = "Bearer 7351c74d.ed9f7e.f9e23db7.c3cfb1c0d3e"
+      get :fake_action
+      expect(response).to have_http_status(:unauthorized)
+      expect(json_response["error"]).to eq I18n.t("api.errors.unexpected_error")
+    end
+  end
+end


### PR DESCRIPTION
Тесты для concern точно такие же как и для api controller, разница лишь в том, что в тестах для concern в качестве анонимного контроллера используется наследник ApplicationController с подключением api responders и api authenticate внутри контроллера, а в тестах API:ApiController анонимным контроллером выступает наследник самого api controller, и подключения concerns напрямую не требуется, так как они уже подключены в родительском классе.
Тесты для ApiController работают без изменений.