### PR TITLE
Fix #162 Add API Tasks controller with show action

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -4,5 +4,11 @@ module Api
 
     include ApiResponders
     include ApiAuthenticate
+
+    private
+
+    def record_not_found(exception)
+      bad_request(t("api.v1.tasks.errors.task_not_found"))
+    end
   end
 end

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V1
+    class TasksController < Api::ApiController
+      before_action :token_authenticate_user
+
+      def show
+        task = Task.find(params[:id])
+        serialized_task = TaskSerializer.new(task).serializable_hash.to_json
+        ok(task: serialized_task)
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,11 +80,14 @@ en:
       sessions:
         errors:
           incorrect_email_or_password: "Incorrect email or password"
-          user_not_found_blocked: "User not found or blocked"
+          user_not_found_blocked: "User is not found or blocked"
           no_email_and_password: "Enter email and password"
+      tasks:
+        errors:
+          task_not_found: "Task is not found"
     errors:
       unauthorized: "You don't have access to that."
-      not_found: "User not found or blocked"
+      not_found: "User is not found or blocked"
       not_bearer_type: "Wrong scheme, you have to use a Bearer"
       blank_token: "Token is nil or empty"
       expired_token: "Token is expired"

--- a/spec/controllers/api/v1/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/tasks_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::TasksController do
+  let(:user) { create(:user) }
+  let(:token) { JwtService.encode(id: user.id, email: user.email, username: user.username) }
+  let(:task) { create(:task) }
+  let(:serialized) { TaskSerializer.new(task).serializable_hash }
+
+  describe "#show" do
+    it "returns serialized task object" do
+      request.headers["Authorization"] = "Bearer #{token}"
+      get :show, params: { id: task.id }
+      expect(json_response["task"]).to eq serialized.to_json
+    end
+
+    it "returns error if user unuathorized" do
+      get :show, params: { id: task.id }
+      expect(json_response["error"]).to eq I18n.t("api.errors.unauthorized")
+    end
+
+    it "returns error if task is not found" do
+      request.headers["Authorization"] = "Bearer #{token}"
+      get :show, params: { id: 10 }
+      expect(json_response["error"]).to eq I18n.t("api.v1.tasks.errors.task_not_found")
+    end
+  end
+end


### PR DESCRIPTION
Добавлен API::V1::TasksController с методом show, тесты написаны, изменена обработка ActiveRecord::RecordNotFound в API::ApiController, добавлены и исправлены ошибки в locales, касающиеся API. Rubocop предлагает при переопределении record_not_found(exception) убрать аргумент или прописать его (_exception) / (*), так как аргумент внутри метода не используется.