### PR TITLE
Fix #182 Api projects controller

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -7,10 +7,6 @@ module Api
 
     private
 
-    def record_not_found(exception)
-      bad_request(t("api.v1.tasks.errors.task_not_found"))
-    end
-
     def user_not_authorized
       unauthorized(t("api.errors.unauthorized"))
     end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -7,6 +7,10 @@ module Api
 
     private
 
+    def record_not_found
+      bad_request(t("api.errors.not_found"))
+    end
+
     def user_not_authorized
       unauthorized(t("api.errors.unauthorized"))
     end

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -4,23 +4,16 @@ module Api
       before_action :token_authenticate_user
 
       def index
-        search = current_user.member_in_project.ransack(params[:q])
-        projects = search.result(distinct: true)
+        projects = current_user.member_in_project
         serialized_projects = ProjectSerializer.new(projects).serializable_hash.to_json
         ok(projects: serialized_projects)
       end
 
       def show
         project = Project.find(params[:id])
-        authorize! project, with: ProjectPolicy
+        authorize! project
         serialized_project = ProjectSerializer.new(project).serializable_hash.to_json
         ok(project: serialized_project)
-      end
-
-      private
-
-      def record_not_found(exception)
-        bad_request(t("api.v1.projects.errors.project_not_found"))
       end
     end
   end

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  module V1
+    class ProjectsController < Api::ApiController
+      before_action :token_authenticate_user
+
+      def index
+        search = current_user.member_in_project.ransack(params[:q])
+        projects = search.result(distinct: true)
+        serialized_projects = ProjectSerializer.new(projects).serializable_hash.to_json
+        ok(projects: serialized_projects)
+      end
+
+      def show
+        project = Project.find(params[:id])
+        authorize! project, with: ProjectPolicy
+        serialized_project = ProjectSerializer.new(project).serializable_hash.to_json
+        ok(project: serialized_project)
+      end
+
+      private
+
+      def record_not_found(exception)
+        bad_request(t("api.v1.projects.errors.project_not_found"))
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -9,6 +9,12 @@ module Api
         serialized_task = TaskSerializer.new(task).serializable_hash.to_json
         ok(task: serialized_task)
       end
+
+      private
+
+      def record_not_found(exception)
+        bad_request(t("api.v1.tasks.errors.task_not_found"))
+      end
     end
   end
 end

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -9,12 +9,6 @@ module Api
         serialized_task = TaskSerializer.new(task).serializable_hash.to_json
         ok(task: serialized_task)
       end
-
-      private
-
-      def record_not_found(exception)
-        bad_request(t("api.v1.tasks.errors.task_not_found"))
-      end
     end
   end
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,6 +1,6 @@
 class ProjectSerializer
   include JSONAPI::Serializer
-  
+
   attributes :title, :status
   attribute :tasks do |object|
     TaskSerializer.new(object.tasks)

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,5 +1,6 @@
 class ProjectSerializer
   include JSONAPI::Serializer
+  
   attributes :title, :status
   attribute :tasks do |object|
     TaskSerializer.new(object.tasks)

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,0 +1,7 @@
+class ProjectSerializer
+  include JSONAPI::Serializer
+  attributes :title, :status
+  attribute :tasks do |object| 
+    TaskSerializer.new(object.tasks)
+  end
+end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,7 +1,7 @@
 class ProjectSerializer
   include JSONAPI::Serializer
   attributes :title, :status
-  attribute :tasks do |object| 
+  attribute :tasks do |object|
     TaskSerializer.new(object.tasks)
   end
 end

--- a/app/serializers/task_serializer.rb
+++ b/app/serializers/task_serializer.rb
@@ -1,5 +1,5 @@
 class TaskSerializer
   include JSONAPI::Serializer
-  
+
   attributes :title, :status
 end

--- a/app/serializers/task_serializer.rb
+++ b/app/serializers/task_serializer.rb
@@ -1,4 +1,5 @@
 class TaskSerializer
   include JSONAPI::Serializer
+  
   attributes :title, :status
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,9 @@ en:
       tasks:
         errors:
           task_not_found: "Task is not found"
+      projects:
+        errors:
+          project_not_found: "Project is not found"
     errors:
       unauthorized: "You don't have access to that."
       not_found: "User is not found or blocked"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,15 +97,9 @@ en:
           incorrect_email_or_password: "Incorrect email or password"
           user_not_found_blocked: "User is not found or blocked"
           no_email_and_password: "Enter email and password"
-      tasks:
-        errors:
-          task_not_found: "Task is not found"
-      projects:
-        errors:
-          project_not_found: "Project is not found"
     errors:
       unauthorized: "You don't have access to that."
-      not_found: "User is not found or blocked"
+      not_found: "Record is not found"
       not_bearer_type: "Wrong scheme, you have to use a Bearer"
       blank_token: "Token is nil or empty"
       expired_token: "Token is expired"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post 'login', to: 'sessions#create'
+      resources :projects, only: [:index, :show]
       resources :tasks, only: :show
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post 'login', to: 'sessions#create'
+
       resources :projects, only: [:index, :show]
+      
       resources :tasks, only: :show
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
     put "marks", to: "project_marks#edit"
   end
 
-  resources :comments, only: [:create, :update, :destroy]
+  resources :comments, only: %i[create update destroy]
 
   resources :favorites, only: %i[index create]
   delete :favorites, to: "favorites#destroy"
@@ -35,8 +35,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       post 'login', to: 'sessions#create'
 
-      resources :projects, only: [:index, :show]
-      
+      resources :projects, only: %i[index show]
+
       resources :tasks, only: :show
     end
   end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::V1::ProjectsController do
 
   describe "GET /api/v1/projects" do
     it "serialized projects object" do
-      request.headers["Authorization"] = "Bearer #{token}"
+      authorization_header(token)
       get :index
       expect(response).to have_http_status(:ok)
     end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V1::ProjectsController do
     end
   end
 
-  describe "GET /api/v1/projects/{project_id}" do
+  describe "GET /api/v1/projects/:id" do
     context "when user is member for project" do
       before do
         create(:project_member, user: user, project: project)

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::ProjectsController do
+  let(:user) { create(:user) }
+  let(:token) { JwtService.encode(id: user.id, email: user.email, username: user.username) }
+  let(:project) { create(:project) }
+  let(:task) { create(:task, project: project) }
+  let(:serialized) { ProjectSerializer.new(project).serializable_hash }
+
+  describe "#index" do
+    it "returns serialized projects object" do
+      request.headers["Authorization"] = "Bearer #{token}"
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "#show" do
+    context "user is member for project" do
+      before do
+        create(:project_member, user: user, project: project)
+      end
+
+      it "returns serialized project object" do
+        request.headers["Authorization"] = "Bearer #{token}"
+        get :show, params: { id: project.id }
+        expect(json_response["project"]).to eq serialized.to_json
+      end
+    end
+
+    context "user is not member for project" do
+      it "returns unauthorized error" do
+        request.headers["Authorization"] = "Bearer #{token}"
+        get :show, params: { id: project.id }
+        expect(json_response["error"]).to eq I18n.t("api.errors.unauthorized")
+      end
+    end
+
+    it "returns error if user unuathorized" do
+      get :show, params: { id: project.id }
+      expect(json_response["error"]).to eq I18n.t("api.errors.unauthorized")
+    end
+
+    it "returns error if task is not found" do
+      request.headers["Authorization"] = "Bearer #{token}"
+      get :show, params: { id: 10 }
+      expect(json_response["error"]).to eq I18n.t("api.v1.projects.errors.project_not_found")
+    end
+  end
+end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -7,44 +7,44 @@ RSpec.describe Api::V1::ProjectsController do
   let(:task) { create(:task, project: project) }
   let(:serialized) { ProjectSerializer.new(project).serializable_hash }
 
-  describe "#index" do
-    it "returns serialized projects object" do
+  describe "GET /api/v1/projects" do
+    it "serialized projects object" do
       request.headers["Authorization"] = "Bearer #{token}"
       get :index
       expect(response).to have_http_status(:ok)
     end
   end
 
-  describe "#show" do
+  describe "GET /api/v1/projects/{project_id}" do
     context "when user is member for project" do
       before do
         create(:project_member, user: user, project: project)
       end
 
-      it "returns serialized project object" do
-        request.headers["Authorization"] = "Bearer #{token}"
+      it "serialized project object" do
+        authorization_header(token)
         get :show, params: { id: project.id }
         expect(json_response["project"]).to eq serialized.to_json
       end
     end
 
     context "when user is not member for project" do
-      it "returns unauthorized error" do
-        request.headers["Authorization"] = "Bearer #{token}"
+      it "unauthorized error" do
+        authorization_header(token)
         get :show, params: { id: project.id }
         expect(json_response["error"]).to eq I18n.t("api.errors.unauthorized")
       end
     end
 
-    it "returns error if user unuathorized" do
+    it "error if user unuathorized" do
       get :show, params: { id: project.id }
       expect(json_response["error"]).to eq I18n.t("api.errors.unauthorized")
     end
 
-    it "returns error if task is not found" do
-      request.headers["Authorization"] = "Bearer #{token}"
+    it "error if task is not found" do
+      authorization_header(token)
       get :show, params: { id: 10 }
-      expect(json_response["error"]).to eq I18n.t("api.v1.projects.errors.project_not_found")
+      expect(json_response["error"]).to eq I18n.t("api.errors.not_found")
     end
   end
 end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Api::V1::ProjectsController do
   end
 
   describe "#show" do
-    context "user is member for project" do
+    context "when user is member for project" do
       before do
         create(:project_member, user: user, project: project)
       end
@@ -28,7 +28,7 @@ RSpec.describe Api::V1::ProjectsController do
       end
     end
 
-    context "user is not member for project" do
+    context "when user is not member for project" do
       it "returns unauthorized error" do
         request.headers["Authorization"] = "Bearer #{token}"
         get :show, params: { id: project.id }

--- a/spec/controllers/api/v1/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/tasks_controller_spec.rb
@@ -7,36 +7,36 @@ RSpec.describe Api::V1::TasksController do
   let(:task) { create(:task, project: project) }
   let(:serialized) { TaskSerializer.new(task).serializable_hash }
 
-  describe "#show" do
-    context "user is member for project" do
+  describe "GET /api/v1/tasks/{task_id}" do
+    context "when user is member for project" do
       before do
         create(:project_member, user: user, project: project)
       end
 
-      it "returns serialized task object" do
-        request.headers["Authorization"] = "Bearer #{token}"
+      it "serialized task object" do
+        authorization_header(token)
         get :show, params: { id: task.id }
         expect(json_response["task"]).to eq serialized.to_json
       end
     end
 
-    context "user is not member for project" do
-      it "returns unauthorized error" do
-        request.headers["Authorization"] = "Bearer #{token}"
+    context "when user is not member for project" do
+      it "unauthorized error" do
+        authorization_header(token)
         get :show, params: { id: task.id }
         expect(json_response["error"]).to eq I18n.t("api.errors.unauthorized")
       end
     end
 
-    it "returns error if user unuathorized" do
+    it "error if user unuathorized" do
       get :show, params: { id: task.id }
       expect(json_response["error"]).to eq I18n.t("api.errors.unauthorized")
     end
 
-    it "returns error if task is not found" do
-      request.headers["Authorization"] = "Bearer #{token}"
+    it "error if task is not found" do
+      authorization_header(token)
       get :show, params: { id: 10 }
-      expect(json_response["error"]).to eq I18n.t("api.v1.tasks.errors.task_not_found")
+      expect(json_response["error"]).to eq I18n.t("api.errors.not_found")
     end
   end
 end

--- a/spec/controllers/api/v1/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/tasks_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V1::TasksController do
   let(:task) { create(:task, project: project) }
   let(:serialized) { TaskSerializer.new(task).serializable_hash }
 
-  describe "GET /api/v1/tasks/{task_id}" do
+  describe "GET /api/v1/tasks/:id" do
     context "when user is member for project" do
       before do
         create(:project_member, user: user, project: project)

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -2,6 +2,10 @@ module ApiHelpers
   def json_response
     JSON.parse(response.body)
   end
+
+  def authorization_header(token)
+    request.headers["Authorization"] = "Bearer #{token}"
+  end
 end
 
 RSpec.configure do |config| 

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -8,6 +8,6 @@ module ApiHelpers
   end
 end
 
-RSpec.configure do |config| 
+RSpec.configure do |config|
   config.include ApiHelpers, type: :controller
 end


### PR DESCRIPTION
1. Добавил api projects controller. Метод index копирует аналогичный метод из обычного projects controller, политика в нем не используется, так как выборка идет на основе current_user == project_member, в данном случае current_user получен из token_authenticate_user. В методе show использовал ProjectPolicy для проверки, новую политику не писал. Оба метода возвращают проект(проекты) + таски;
2. Добавил ProjectSerializer;
3. Метод record_not_found перенес из api controller в контроллеры project и task, так как у них разные сообщения об ошибке;
4. Тесты работают.